### PR TITLE
Tuning the way we load images in a bit more

### DIFF
--- a/src/components/BlockContent/index.tsx
+++ b/src/components/BlockContent/index.tsx
@@ -123,7 +123,7 @@ const BlockContent: React.FC<BlockContentProps> = ({ content }) => {
           <Link
             href={value.href}
             rel={rel}
-            className="underline text-purple-700 hover:text-purple-800 hover:no-underline hover:underline-offset-4 transition-colors"
+            className="underline underline-offset-4 text-purple-700 hover:text-purple-800 hover:no-underline transition-colors"
           >
             {children}
           </Link>

--- a/src/components/BlogHeader/index.tsx
+++ b/src/components/BlogHeader/index.tsx
@@ -51,7 +51,7 @@ const BlogHeader: React.FC<BlogHeaderProps> = ({
             {author.slug?.current ? (
               <Link
                 href={`/author/${author.slug.current}`}
-                className="font-medium text-primary ml-1 hover:underline"
+                className="font-medium text-primary ml-1 underline underline-offset-4 hover:no-underline"
               >
                 {author.name}
               </Link>
@@ -77,9 +77,9 @@ const BlogHeader: React.FC<BlogHeaderProps> = ({
       </div>
 
       {mainImage?.asset && (
-        <figure className="mb-8 relative w-full h-[450px] rounded-lg overflow-hidden">
+        <figure className="mb-8 relative aspect-square sm:aspect-[1510/450] w-full rounded-lg overflow-hidden">
           <Image
-            src={urlFor(mainImage).width(1510).height(450).fit('crop').crop('entropy').url()}
+            src={urlFor(mainImage).width(1510).height(450).quality(80).url()}
             alt={mainImage.alt || title}
             fill
             priority

--- a/src/components/PostCard/index.tsx
+++ b/src/components/PostCard/index.tsx
@@ -27,7 +27,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, category, postUrl, isFeatured
 
   // Generate image URL with proper dimensions
   const imageUrl = post.mainImage?.asset
-    ? urlFor(post.mainImage).width(imageWidth).height(imageHeight).fit('crop').crop('entropy').url()
+    ? urlFor(post.mainImage).width(imageWidth).height(imageHeight).url()
     : '';
 
   return (
@@ -49,7 +49,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, category, postUrl, isFeatured
                 }
                 quality={isFeatured ? 90 : 75}
               />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/50 to-black/30"></div>
+              <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/20 to-transparent"></div>
             </>
           ) : (
             <div className="h-full bg-gray-800 flex items-center justify-center">
@@ -63,7 +63,7 @@ const PostCard: React.FC<PostCardProps> = ({ post, category, postUrl, isFeatured
             </h2>
 
             {post.publishedAt && (
-              <div className="text-white/80 text-xs font-medium mt-2">
+              <div className="text-white/90 text-xs font-medium mt-2 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]">
                 {formatDate(post.publishedAt)}
               </div>
             )}


### PR DESCRIPTION
- I've decided to use Sanity's built in 'hotspot and crop' feature to determine how to serve images, so I've removed the `fit` and `crop` features from `BlogHeader` and `PostCard` I've also bumped the hero image quality up a bit to 80 as it was defaulting to 70 and I wasn't entirely happy with the quality.